### PR TITLE
Misc fixups that may be of interest (don't merge as-is)

### DIFF
--- a/AppRun.c
+++ b/AppRun.c
@@ -92,7 +92,7 @@ static void add_path(const char* name, const char* rootdir) {
 }
 
 #define SAVE_ENV_VAR(x) char *x = getenv(#x)
-#define LOAD_ENV_VAR(x) setenv(#x, x, 1)
+#define LOAD_ENV_VAR(x) do { if (x != NULL) setenv(#x, x, 1); } while(0)
 
 int main(int argc, char *argv[]) {
     char *appdir = dirname(realpath("/proc/self/exe", NULL));

--- a/appdir.nix
+++ b/appdir.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, perl, pathsFromGraph, fetchFromGitHub, musl, coreutils, bash }:
+{ stdenv, fetchurl, muslPkgs, perl, pathsFromGraph, fetchFromGitHub, coreutils, bash }:
 
 let
-  AppRun = targets: stdenv.mkDerivation {
+  AppRun = targets: muslPkgs.stdenv.mkDerivation {
     name = "AppRun";
 
     phases = [ "buildPhase" "installPhase" "fixupPhase" ];
 
     buildPhase = ''
-      CC="${musl}/bin/musl-gcc -O2 -Wall -Wno-deprecated-declarations -Wno-unused-result -static"
+      CC="$CC -O2 -Wall -Wno-deprecated-declarations -Wno-unused-result -static"
       $CC ${./AppRun.c} -o AppRun -DENV_PATH='"${stdenv.lib.makeBinPath targets}"'
     '';
 

--- a/appimage-top.nix
+++ b/appimage-top.nix
@@ -1,13 +1,17 @@
-{nixpkgs ? import <nixpkgs> {}}:
+{ nixpkgs' ? <nixpkgs> }:
 
-with nixpkgs;
+let
+  pkgs = import nixpkgs' { };
+  muslPkgs = import nixpkgs' {
+    localSystem.config = "x86_64-unknown-linux-musl";
+  };
 
-rec {
-  appimagetool = callPackage ./appimagetool.nix {};
+in rec {
+  appimagetool = pkgs.callPackage ./appimagetool.nix {};
 
-  appimage = callPackage ./appimage.nix {
+  appimage = pkgs.callPackage ./appimage.nix {
     inherit appimagetool;
   };
 
-  appdir = callPackage ./appdir.nix {};
+  appdir = pkgs.callPackage ./appdir.nix { inherit muslPkgs; };
 }

--- a/appimagetool.nix
+++ b/appimagetool.nix
@@ -5,7 +5,9 @@
 # Ideally, this should be source based,
 # but I can't get it to build from GitHub
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.cc.bintools) dynamicLinker;
+in stdenv.mkDerivation rec {
   name = "appimagekit";
 
   src = fetchurl {
@@ -22,7 +24,7 @@ stdenv.mkDerivation rec {
   unpackPhase = ''
     cp $src appimagetool-x86_64.AppImage
     chmod u+wx appimagetool-x86_64.AppImage
-    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+    patchelf --set-interpreter ${dynamicLinker} \
              --set-rpath ${fuse}/lib:${zlib}/lib \
              appimagetool-x86_64.AppImage
     ./appimagetool-x86_64.AppImage --appimage-extract
@@ -32,10 +34,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -r usr/* $out
 
-    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+    patchelf --set-interpreter ${dynamicLinker} \
          --set-rpath ${stdenv.glibc.out}/lib:${fuse}/lib:${zlib}/lib:${glib}/lib \
 	 $out/bin/appimagetool
-    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+    patchelf --set-interpreter ${dynamicLinker} \
          --set-rpath ${zlib}/lib \
 	 $out/bin/mksquashfs
   '';

--- a/appimagetool.nix
+++ b/appimagetool.nix
@@ -11,8 +11,8 @@ in stdenv.mkDerivation rec {
   name = "appimagekit";
 
   src = fetchurl {
-    url = "https://github.com/probonopd/AppImageKit/releases/download/7/appimagetool-x86_64.AppImage";
-    sha256 = "1irvbf0xnya16cyzpvr43jviq5ly3wl7b9753rji7d1hhxwb7b9r";
+    url = "https://github.com/AppImage/AppImageKit/releases/download/10/appimagetool-x86_64.AppImage";
+    sha256 = "03zbiblj8a1yk1xsb5snxi4ckwn3diyldg1jh5hdjjhsmpw652ig";
   };
 
   buildInputs = [

--- a/appimagetool.nix
+++ b/appimagetool.nix
@@ -34,12 +34,12 @@ in stdenv.mkDerivation rec {
     mkdir -p $out
     cp -r usr/* $out
 
-    patchelf --set-interpreter ${dynamicLinker} \
-         --set-rpath ${stdenv.glibc.out}/lib:${fuse}/lib:${zlib}/lib:${glib}/lib \
-	 $out/bin/appimagetool
-    patchelf --set-interpreter ${dynamicLinker} \
-         --set-rpath ${zlib}/lib \
-	 $out/bin/mksquashfs
+    for x in $out/bin/*; do
+      patchelf \
+        --set-interpreter ${dynamicLinker} \
+        --set-rpath ${stdenv.lib.makeLibraryPath [ zlib stdenv.glibc.out fuse glib ]} \
+        $x
+    done
   '';
 
   dontStrip = true;

--- a/test-appimage.nix
+++ b/test-appimage.nix
@@ -1,0 +1,14 @@
+{ appimagefile, nixpkgs' ? <nixpkgs> }:
+
+# nix build -f test-appimage.nix --arg appimagefile ./VLC*AppImage
+
+with import nixpkgs' {};
+
+runCommand "patchelf" {} ''
+  cp ${appimagefile} $out
+  chmod +w $out
+  patchelf \
+    --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+    --set-rpath ${stdenv.glibc.out}/lib:${fuse}/lib:${zlib}/lib:${glib}/lib \
+    $out
+''


### PR DESCRIPTION
Builds on top of #26 

* Fixes #24 (using mostly the suggested approach)
* Fixes to work with latest nixpkgs which does not have musl-gcc, instead just use musl-native stdenv
* minor cleanup to use dynamicLinker string from bintools, but might not want this since requires however-recent nixpkgs.  Shrug.
* Updated appimagetool to 10 and reverted, didn't explore what broke :innocent:
* Add a really quick nix file for patchelf'ing appimage's generated so they execute.

With these, was able to do:

```console
$ NIX_PATH=nixpkgs=channel:nixos-unstable ./nix2appimage.sh vlc
$ NIX_PATH=nixpkgs=channel:nixos-unstable nix build -f test-appimage.nix --arg appimagefile ./VLC*AppImage
$ ./result
<VLC runs>
```

Don't have immediate access to a non-NixOS machine with a display server (and new-enough kernel/permissions to support appimage-ness), so haven't tested elsewhere.

LMK if any of this looks useful, or just cherry-pick as you see fit, just thought I'd share in case it helps.
