### PR TITLE
auto-delete the tmpdir when finished

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ rec {
     stdenv.mkDerivation {
       name = "arx";
       buildCommand = ''
-        ${haskellPackages.arx}/bin/arx tmpx ${archive} -rm! -o $out // ${startup}
+        ${haskellPackages.arx}/bin/arx tmpx ${archive} -o $out // ${startup}
         chmod +x $out
       '';
     };


### PR DESCRIPTION
with `-rm!` present, this results in a ~300mb tmp directory being left in `/tmp` for every single invocation of the bundle