### PR TITLE
relocation to allow writing

### DIFF
--- a/appimage.nix
+++ b/appimage.nix
@@ -5,7 +5,9 @@ stdenv.mkDerivation {
   name = "appimage";
   buildInputs = [ appimagetool ];
   buildCommand = ''
-    ARCH=x86_64 appimagetool ${dir}/*.AppDir
+    cp -r ${dir}/* .
+    chmod +w *.AppDir
+    ARCH=x86_64 appimagetool *.AppDir
     mkdir $out
     cp *.AppImage $out
   '';

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ rec {
     stdenv.mkDerivation {
       name = "arx";
       buildCommand = ''
-        ${(import <nixpkgs> {}).haskellPackages.arx}/bin/arx tmpx -rm! ${archive} -o $out // ${startup}
+        ${nixpkgs.haskellPackages.arx}/bin/arx tmpx -rm! ${archive} -o $out // ${startup}
         chmod +x $out
       '';
     };


### PR DESCRIPTION
This was needed for me to use nix-bundle, specifically the AppImage tool. Roughly, appimage needs write access to the AppDir.