### PR TITLE
fix the startup script to run on dash based systems

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -70,7 +70,8 @@ in rec {
 
   makeStartup = { target, nixUserChrootFlags, nix-user-chroot', run }:
   writeScript "startup" ''
-.${nix-user-chroot'}/bin/nix-user-chroot -n ./nix ${nixUserChrootFlags} -- ${target}${run} $@
+    #!/bin/sh
+    .${nix-user-chroot'}/bin/nix-user-chroot -n ./nix ${nixUserChrootFlags} -- ${target}${run} $@
   '';
 
   nix-bootstrap = { target, extraTargets ? [], run, nix-user-chroot' ? nix-user-chroot, nixUserChrootFlags ? "" }:


### PR DESCRIPTION
`[pid  2158] execve("./nix/store/9ymkjxrd09pjmjnmvqzibz5sydqafz0c-startup", ["./nix/store/9ymkjxrd09pjmjnmvqzi"...], [/* 64 vars */]) = -1 ENOENT (No such file or directory)`

if you try to execute a `+x`'d script that lacks a `#!` line, the linux kernel will fail with the above error
but if `/bin/sh` is bash based, it will auto-detect that, and silently do the right thing, so the mistake goes un-noticed

however, ubuntu uses dash for `/bin/sh`, and that appears to lack the same intelligence