### PR TITLE
Pass `/root` through chroot

### DIFF
--- a/nix-user-chroot/main.cpp
+++ b/nix-user-chroot/main.cpp
@@ -120,6 +120,7 @@ int main(int argc, char *argv[]) {
   x("etc");
   x("usr");
   x("home");
+  x("root");
 #undef x
 
   int opt;


### PR DESCRIPTION
This PR adds a `/root:root` mapping so that users with UID 0 can run bundles that use `$HOME`. Related to #33 .