### PR TITLE
Allow bundle to handle an evaluated nix expression

### DIFF
--- a/appdir.nix
+++ b/appdir.nix
@@ -42,7 +42,7 @@ in
       cd $out/${name}.AppDir
 
       mkdir -p nix/store
-      cp -Lr $storePaths nix/store
+      cp -r $storePaths nix/store
 
       ln -s .${target} usr
 

--- a/appimage-bundle.nix
+++ b/appimage-bundle.nix
@@ -18,26 +18,17 @@ let
       src = env;
       inherit exec;
       buildInputs = [ drv ];
-      usr_fonts = buildEnv {
-        name = "fonts";
-        paths = [noto-fonts];
-      };
       buildCommand = ''
-        source $stdenv/setup
-        mkdir $out
+        mkdir -p $out/share/icons/hicolor/256x256/apps
+        mkdir -p $out/share/applications
+
         shopt -s extglob
         ln -s ${env}/!(share) $out/
-        mkdir -p $out/share/fonts
         ln -s ${env}/share/* $out/share/
 
-        cp ${usr_fonts}/share/fonts/* $out/share/fonts -R
-
-        mkdir -p $out/share/icons
-        mkdir -p $out/share/icons/hicolor/256x256/apps
         touch $out/share/icons/hicolor/256x256/apps/${drv.name}.png
         touch $out/share/icons/${drv.name}.png
 
-        mkdir -p $out/share/applications
         cat <<EOF > $out/share/applications/${drv.name}.desktop
         [Desktop Entry]
         Type=Application


### PR DESCRIPTION
Removed some dependencies that are not needed and added the ability to put a nix expression into the package argument.

Example (note the --arg vs --argstr for the package argument):
nix-build appimage-bundle.nix --arg package 'with import <nixpkgs>{}; writers.writePython3Bin "helloThere.py" {} "print(1)\n"' --argstr exec helloThere.py