### PR TITLE
WIP: use proot and xz

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -30,35 +30,20 @@ in rec {
         tar -cf - \
           --owner=0 --group=0 --mode=u+rw,uga+r \
           --hard-dereference \
-          $storePaths | bzip2 -z > $out
+          $storePaths | xz -1 -T $(nproc) > $out
       '';
     };
 
-  # TODO: eventually should this go in nixpkgs?
-  nix-user-chroot = stdenv.lib.makeOverridable stdenv.mkDerivation {
-    name = "nix-user-chroot-2c52b5f";
-    src = ./nix-user-chroot;
-
-    makeFlags = [];
-
+  proot' = proot.overrideAttrs (_: {
     # hack to use when /nix/store is not available
     postFixup = ''
-      exe=$out/bin/nix-user-chroot
+      exe=$out/bin/proot
       patchelf \
         --set-interpreter .$(patchelf --print-interpreter $exe) \
         --set-rpath $(patchelf --print-rpath $exe | sed 's|/nix/store/|./nix/store/|g') \
         $exe
     '';
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/bin/
-      cp nix-user-chroot $out/bin/nix-user-chroot
-
-      runHook postInstall
-    '';
-  };
+  });
 
   makebootstrap = { targets, startup }:
     arx {
@@ -68,15 +53,15 @@ in rec {
       };
     };
 
-  makeStartup = { target, nixUserChrootFlags, nix-user-chroot', run }:
-  writeScript "startup" ''
-    #!/bin/sh
-    .${nix-user-chroot'}/bin/nix-user-chroot -n ./nix ${nixUserChrootFlags} -- ${target}${run} $@
-  '';
+  makeStartup = { target, nixUserChrootFlags, proot, run }:
+    writeScript "startup" ''
+      #!/bin/sh
+      .${proot}/bin/proot -b ./nix:/nix ${target}${run} $@
+    '';
 
-  nix-bootstrap = { target, extraTargets ? [], run, nix-user-chroot' ? nix-user-chroot, nixUserChrootFlags ? "" }:
+  nix-bootstrap = { target, extraTargets ? [], run, proot ? proot', nixUserChrootFlags ? "" }:
     let
-      script = makeStartup { inherit target nixUserChrootFlags nix-user-chroot' run; };
+      script = makeStartup { inherit target nixUserChrootFlags proot run; };
     in makebootstrap {
       startup = ".${script} '\"$@\"'";
       targets = [ "${script}" ] ++ extraTargets;
@@ -90,13 +75,10 @@ in rec {
 
   # special case adding path to the environment before launch
   nix-bootstrap-path = let
-    nix-user-chroot'' = targets: nix-user-chroot.overrideDerivation (o: {
-      buildInputs = o.buildInputs ++ targets;
-      makeFlags = o.makeFlags ++ [
-        ''ENV_PATH="${stdenv.lib.makeBinPath targets}"''
-      ];
+    proot'' = targets: proot'.overrideDerivation (o: {
+      # TODO: not sure yet what we need to do here
     }); in { target, extraTargets ? [], run }: nix-bootstrap {
       inherit target extraTargets run;
-      nix-user-chroot' = nix-user-chroot'' extraTargets;
+      proot = proot'' extraTargets;
     };
 }


### PR DESCRIPTION
(currently based against v0.4.0 since master is broken)

I switched out nix-user-chroot with proot, since proot doesn't require userspaces and therefore should work on all distros.
This should solve https://github.com/matthewbauer/nix-bundle/issues/50

I also swapped out bzip2 with `xz -1` (lzma) which uses multiple cores to compress and also should be significantly faster to extract according to online benchmarks (see for example: https://www.rootusers.com/gzip-vs-bzip2-vs-xz-performance-comparison/)

Alternatively we could use gzip/pigz to compress, which would be even faster to decompress, but the file size will be much larger.
I found `xz -1` to be a good middle ground.

The current problem is that some dependencies of proot seem to be missing. If I execute the bundled binary inside an alpine docker container it raises the following error:
`
./nix/store/mmcsv1szs7w0mjh430jrvj2nrhz6rwr8-proot-20190510/bin/proot: error while loading shared libraries: libgcc_s.so.1: cannot open shared object file: Error 20
`
@matthewbauer Any idea how to solve that?

Also I don't quite understand what the PATH_ENV variable previously set in makeFlags of nix-user-chroot was needed for.
Maybe that could be the missing part.

Tested via:
```
let
  pkgs = import <unstable> {};
  nixBundle = import ./nix-bundle { nixpkgs = pkgs; };
in

nixBundle.nix-bootstrap-path {
  target = pkgs.hello;
  run = "/bin/hello"; 
}
```