### PR TITLE
nix-bundle: print the output path instead

### DIFF
--- a/nix-bundle.sh
+++ b/nix-bundle.sh
@@ -59,5 +59,5 @@ elif [ -t 1 ]; then
   echo "Nix bundle created at $filename."
   cp -f "$out" "$filename"
 else
-  cat "$out"
+  echo "$out"
 fi


### PR DESCRIPTION
When nix-bundle is invoked without a TTY, output the store path instead
of catting the content. This allows more flexibility.