### PR TITLE
Add missing quotes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         nix-bundle = import self { nixpkgs = nixpkgs'; };
         script = nixpkgs'.writeScript "startup" ''
           #!/bin/sh
-          .${nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -- ${program} $@
+          .${nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -- ${program} "$@"
         '';
       in nix-bundle.makebootstrap {
         targets = [ script ];


### PR DESCRIPTION
Before:
```
$ /nix/store/10bnmxbki7mhwaacs605m8fjiswg3jdv-arx -c "echo abc"
Open On-Chip Debugger 0.10.0+dev-snapshot (2021-01-18-22:12)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Unexpected command line argument: abc
```

After:
```
$ /nix/store/l6g76xbmna092aads0plbvz7z962ygrn-arx -c "echo abc"
Open On-Chip Debugger 0.10.0+dev-snapshot (2021-01-18-22:12)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
abc
...
```