### PR TITLE
User proper compiler for nix-user-chroot

### DIFF
--- a/nix-user-chroot/Makefile
+++ b/nix-user-chroot/Makefile
@@ -1,4 +1,4 @@
 ENV_PATH ?= ""
 
 nix-user-chroot: main.cpp
-	g++ -o nix-user-chroot -DENV_PATH='$(ENV_PATH)' main.cpp
+	${CXX} -o nix-user-chroot -DENV_PATH='$(ENV_PATH)' main.cpp


### PR DESCRIPTION
Without this cross-compiling and compiling static binaries is broken.

---

Aside: we could compile nix-user-chroot as a static binary instead of patching the binary to use local nix store.