### PR TITLE
fix for libgcc_s.so.1 linking issue

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,6 +49,10 @@ in rec {
     name = "nix-user-chroot-2c52b5f";
     src = ./nix-user-chroot;
 
+    buildInputs = [
+      stdenv.cc.cc.libgcc or null
+    ];
+
     makeFlags = [];
 
     # hack to use when /nix/store is not available


### PR DESCRIPTION
There was a change in nixpkgs recently, which requires to explicitly define `libgcc_s`. Right now the bundled package builds successfully but complains that there's no `libgcc_s.so.1` when `nix-user-chroot` is started.