### PR TITLE
Use drv.name when pname not exists

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,9 +13,17 @@ rec {
     # in the context automatically.
     else "${target}";
 
-  arx = { drvToBundle, archive, startup}:
+  arx = { drvToBundle, archive, startup }:
+    let
+      name =
+        if drvToBundle != null && drvToBundle ? pname then
+          "${drvToBundle.pname}-arx"
+        else if drvToBundle != null && drvToBundle ? name then
+          "${drvToBundle.name}-arx"
+        else "arx";
+    in
     stdenv.mkDerivation {
-      name = if drvToBundle != null then "${drvToBundle.pname}-arx" else "arx";
+      inherit name;
       passthru = {
         inherit drvToBundle;
       };


### PR DESCRIPTION
Some derivations only defines `name` attribute and cause bundle error like issue #115. This PR add a fallback mechanism that will use `name` attribute when `pname` is not defined. 